### PR TITLE
Updating Kubectl & Helm Deployments to apiVersion:app/v1

### DIFF
--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -4,19 +4,19 @@ metadata:
   name: kubernetes-sidecar-injector-deployment
   namespace: {{ .Values.namespace }}
   labels:
-    app: kubernetes-sidecar-injector
+    app: {{ .Values.app_name }}
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: kubernetes-sidecar-injector
+      app: {{ .Values.app_name }}
   template:
     metadata:
       labels:
-        app: kubernetes-sidecar-injector
+        app: {{ .Values.app_name }}
     spec:
       containers:
-        - name: kubernetes-sidecar-injector
+        - name: {{ .Values.app_name }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: IfNotPresent
           args:

--- a/deployment/helm/templates/deployment.yaml
+++ b/deployment/helm/templates/deployment.yaml
@@ -1,11 +1,15 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: kubernetes-sidecar-injector-deployment
+  namespace: {{ .Values.namespace }}
   labels:
     app: kubernetes-sidecar-injector
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kubernetes-sidecar-injector
   template:
     metadata:
       labels:

--- a/deployment/helm/templates/mutatingwebhook-template.yaml
+++ b/deployment/helm/templates/mutatingwebhook-template.yaml
@@ -2,6 +2,7 @@
 {{- $cn := printf "%s-%s" .Release.Name .Chart.Name }}
 {{- $altName1 := "kubernetes-sidecar-injector-svc.default.svc" }}
 {{- $cert := genSignedCert $cn nil (list $altName1) 3650 $ca }}
+
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:

--- a/deployment/helm/templates/mutatingwebhook-template.yaml
+++ b/deployment/helm/templates/mutatingwebhook-template.yaml
@@ -5,6 +5,7 @@
 apiVersion: admissionregistration.k8s.io/v1beta1
 kind: MutatingWebhookConfiguration
 metadata:
+  namespace: {{ .Values.namespace }}
   name: kubernetes-sidecar-injector-webhook
   labels:
     app: kubernetes-sidecar-injector

--- a/deployment/helm/templates/sidecar-configmap.yaml
+++ b/deployment/helm/templates/sidecar-configmap.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: {{ .Values.namespace }}
   name: kubernetes-sidecars-configmap
 data:
   sidecarconfig.yaml: |
@@ -30,6 +31,7 @@ data:
 apiVersion: v1
 kind: ConfigMap
 metadata:
+  namespace: {{ .Values.namespace }}
   name: haystack-agent-conf-configmap
 data:
   agent.conf: |

--- a/deployment/helm/templates/sidecar-injector-service.yaml
+++ b/deployment/helm/templates/sidecar-injector-service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: kubernetes-sidecar-injector-svc
+  namespace: {{ .Values.namespace }}
   labels:
     app: sidecar-injector
 spec:

--- a/deployment/helm/templates/sidecar-injector-service.yaml
+++ b/deployment/helm/templates/sidecar-injector-service.yaml
@@ -10,4 +10,4 @@ spec:
   - port: 443
     targetPort: 8443
   selector:
-    app: kubernetes-sidecar-injector
+    app: {{ .Values.app_name }}

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -3,6 +3,7 @@
 # Declare name/value pairs to be passed into your templates.
 # name: value
 
+namespace: sidecar-webhook
 image:
   repository: expediadotcom/kubernetes-sidecar-injector
   tag: latest

--- a/deployment/helm/values.yaml
+++ b/deployment/helm/values.yaml
@@ -4,6 +4,9 @@
 # name: value
 
 namespace: sidecar-webhook
+
+app_name: kubernetes-sidecar-injector
+
 image:
   repository: expediadotcom/kubernetes-sidecar-injector
   tag: latest

--- a/deployment/kubectl/sidecar-injector-deployment.yaml
+++ b/deployment/kubectl/sidecar-injector-deployment.yaml
@@ -1,11 +1,15 @@
-apiVersion: extensions/v1beta1
+apiVersion: app/v1
 kind: Deployment
 metadata:
+  namespace: {{ .Values.namespace }}
   name: kubernetes-sidecar-injector-deployment
   labels:
     app: kubernetes-sidecar-injector
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: kubernetes-sidecar-injector
   template:
     metadata:
       labels:


### PR DESCRIPTION
Hello,

I received some validation errors when trying to install this into my cluster. I bumped

1. the deployments to apiVersion: app/v1 (from extension/betav1)
2. added the `selector.matchLabels` per the validation of app/v1
3. pulled out the app_name to the helm chart values.yaml
4. added a namespace option to the helm chart values.yaml