### PR TITLE
Adds GHA to release the helm charts on commit to master

### DIFF
--- a/.github/workflows/release_chart.yaml
+++ b/.github/workflows/release_chart.yaml
@@ -1,0 +1,27 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.8.0
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.3.0
+        env:
+          CR_TOKEN: "${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -74,4 +74,11 @@ data:
             - name: workdir
               mountPath: "/work-dir"
 ```
+## How to use the kubernetes-sidecar-injector Helm repository
 
+You need to add this repository to your Helm repositories:
+
+```
+helm repo add kubernetes-sidecar-injector  https://opensource.expediagroup.com/kubernetes-sidecar-injector/
+helm repo update
+```


### PR DESCRIPTION
URL: https://opensource.expediagroup.com/kubernetes-sidecar-injector/