### PR TITLE
Fix haystack-agent image in the "echo-server" example

### DIFF
--- a/sample/chart/echo-server/templates/sidecar-configmap.yaml
+++ b/sample/chart/echo-server/templates/sidecar-configmap.yaml
@@ -8,7 +8,7 @@ data:
     - name: haystack-agent
       containers:
         - name: haystack-agent
-          image: expediagroup/haystack-agent
+          image: expediadotcom/haystack-agent
           imagePullPolicy: IfNotPresent
           args:
             - --config-provider


### PR DESCRIPTION
<!--
Thank you for submitting a pull request!

Please verify that:
* [ ] Code is up-to-date with the `main` branch.
* [ ] You've successfully built and run the tests locally.
* [ ] There are new or updated unit tests validating the change.

Refer to CONTRIBUTING.md for more details.
-->

### :pencil: Description
- Looks like `expediagroup/haystack-agent` image doesn't exist (anymore?), so `make install-sample-container` doesn't work properly. `expediadotcom/haystack-agent` seems to work fine.

