### PR TITLE
fix(Escape Labels/Annotations that contain special characters)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,20 +1,25 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/expediagroup/kubernetes-sidecar-injector/pkg/httpd"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"os"
 )
 
 var (
 	httpdConf httpd.SimpleServer
+	debug     bool
 )
 
 var rootCmd = &cobra.Command{
 	Use:   "kubernetes-sidecar-injector",
 	Short: "Responsible for injecting sidecars into pod containers",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if debug {
+			log.SetLevel(log.DebugLevel)
+		}
 		log.Infof("SimpleServer starting to listen in port %v", httpdConf.Port)
 		return httpdConf.Start()
 	},
@@ -36,4 +41,5 @@ func init() {
 	rootCmd.Flags().StringVar(&(&httpdConf.Patcher).InjectPrefix, "injectPrefix", "sidecar-injector.expedia.com", "Injector Prefix")
 	rootCmd.Flags().StringVar(&(&httpdConf.Patcher).InjectName, "injectName", "inject", "Injector Name")
 	rootCmd.Flags().StringVar(&(&httpdConf.Patcher).SidecarDataKey, "sidecarDataKey", "sidecars.yaml", "ConfigMap Sidecar Data Key")
+	rootCmd.Flags().BoolVar(&debug, "debug", false, "enable debug logs")
 }

--- a/pkg/httpd/simpleserver.go
+++ b/pkg/httpd/simpleserver.go
@@ -2,6 +2,10 @@ package httpd
 
 import (
 	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
 	"github.com/expediagroup/kubernetes-sidecar-injector/pkg/admission"
 	"github.com/expediagroup/kubernetes-sidecar-injector/pkg/webhook"
 	"github.com/pkg/errors"
@@ -9,9 +13,6 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
-	"net/http"
-	"os"
-	"path/filepath"
 )
 
 /*SimpleServer is the required config to create httpd server*/
@@ -21,6 +22,7 @@ type SimpleServer struct {
 	CertFile string
 	KeyFile  string
 	Patcher  webhook.SidecarInjectorPatcher
+	Debug    bool
 }
 
 /*Start the simple http server supporting TLS*/

--- a/pkg/webhook/sidecarhandler.go
+++ b/pkg/webhook/sidecarhandler.go
@@ -94,6 +94,7 @@ func createObjectPatches(newMap map[string]string, existingMap map[string]string
 	} else {
 		for key, value := range newMap {
 			if _, ok := existingMap[key]; !ok || (ok && override) {
+				key = escapeJSONPath(key)
 				op := "add"
 				if ok {
 					op = "replace"
@@ -107,6 +108,13 @@ func createObjectPatches(newMap map[string]string, existingMap map[string]string
 		}
 	}
 	return patches
+}
+
+// Escape keys that may contain `/`s or `~`s to have a valid patch
+// Order matters here, otherwise `/` --> ~01, instead of ~1
+func escapeJSONPath(k string) string {
+	k = strings.ReplaceAll(k, "~", "~0")
+	return strings.ReplaceAll(k, "/", "~1")
 }
 
 // PatchPodCreate Handle Pod Create Patch

--- a/pkg/webhook/sidecarhandler_test.go
+++ b/pkg/webhook/sidecarhandler_test.go
@@ -582,6 +582,19 @@ func Test_createObjectPatches(t *testing.T) {
 			}},
 		},
 		{
+			name: "test dots",
+			args: args{
+				newMap:      map[string]string{"example.com/my": "label"},
+				existingMap: nil,
+				path:        "/metadata/labels",
+			},
+			want: []admission.PatchOperation{{
+				Op:    "add",
+				Path:  "/metadata/labels",
+				Value: map[string]string{"example.com/my": "label"},
+			}},
+		},
+		{
 			name: "test patching label no override",
 			args: args{
 				newMap:      map[string]string{"my": "label"},

--- a/pkg/webhook/sidecarhandler_test.go
+++ b/pkg/webhook/sidecarhandler_test.go
@@ -520,6 +520,19 @@ func Test_createObjectPatches(t *testing.T) {
 			}},
 		},
 		{
+			name: "test patching empty annotation with special characters",
+			args: args{
+				newMap:      map[string]string{"example.com/my": "annotation"},
+				existingMap: map[string]string{},
+				path:        "/metadata/annotations",
+			},
+			want: []admission.PatchOperation{{
+				Op:    "add",
+				Path:  "/metadata/annotations/example.com~1my",
+				Value: "annotation",
+			}},
+		},
+		{
 			name: "test patching nil annotation",
 			args: args{
 				newMap:      map[string]string{"my": "annotation"},
@@ -592,19 +605,6 @@ func Test_createObjectPatches(t *testing.T) {
 				Op:    "add",
 				Path:  "/metadata/labels",
 				Value: map[string]string{"my": "label"},
-			}},
-		},
-		{
-			name: "test dots",
-			args: args{
-				newMap:      map[string]string{"example.com/my": "label"},
-				existingMap: nil,
-				path:        "/metadata/labels",
-			},
-			want: []admission.PatchOperation{{
-				Op:    "add",
-				Path:  "/metadata/labels",
-				Value: map[string]string{"example.com/my": "label"},
 			}},
 		},
 		{

--- a/pkg/webhook/sidecarhandler_test.go
+++ b/pkg/webhook/sidecarhandler_test.go
@@ -569,6 +569,19 @@ func Test_createObjectPatches(t *testing.T) {
 			}},
 		},
 		{
+			name: "test patching empty labels with special characters",
+			args: args{
+				newMap:      map[string]string{"example.com/my": "label"},
+				existingMap: map[string]string{},
+				path:        "/metadata/labels",
+			},
+			want: []admission.PatchOperation{{
+				Op:    "add",
+				Path:  "/metadata/labels/example.com~1my",
+				Value: "label",
+			}},
+		},
+		{
 			name: "test patching nil labels",
 			args: args{
 				newMap:      map[string]string{"my": "label"},

--- a/pkg/webhook/sidecarhandler_test.go
+++ b/pkg/webhook/sidecarhandler_test.go
@@ -520,7 +520,7 @@ func Test_createObjectPatches(t *testing.T) {
 			}},
 		},
 		{
-			name: "test patching empty annotation with special characters",
+			name: "test patching empty annotation with forward slash",
 			args: args{
 				newMap:      map[string]string{"example.com/my": "annotation"},
 				existingMap: map[string]string{},
@@ -529,6 +529,19 @@ func Test_createObjectPatches(t *testing.T) {
 			want: []admission.PatchOperation{{
 				Op:    "add",
 				Path:  "/metadata/annotations/example.com~1my",
+				Value: "annotation",
+			}},
+		},
+		{
+			name: "test patching empty annotation with tilde",
+			args: args{
+				newMap:      map[string]string{"example.com~my": "annotation"},
+				existingMap: map[string]string{},
+				path:        "/metadata/annotations",
+			},
+			want: []admission.PatchOperation{{
+				Op:    "add",
+				Path:  "/metadata/annotations/example.com~0my",
 				Value: "annotation",
 			}},
 		},
@@ -582,7 +595,7 @@ func Test_createObjectPatches(t *testing.T) {
 			}},
 		},
 		{
-			name: "test patching empty labels with special characters",
+			name: "test patching empty labels with forward slash",
 			args: args{
 				newMap:      map[string]string{"example.com/my": "label"},
 				existingMap: map[string]string{},
@@ -591,6 +604,19 @@ func Test_createObjectPatches(t *testing.T) {
 			want: []admission.PatchOperation{{
 				Op:    "add",
 				Path:  "/metadata/labels/example.com~1my",
+				Value: "label",
+			}},
+		},
+		{
+			name: "test patching empty labels with tilde",
+			args: args{
+				newMap:      map[string]string{"example.com~my": "label"},
+				existingMap: map[string]string{},
+				path:        "/metadata/labels",
+			},
+			want: []admission.PatchOperation{{
+				Op:    "add",
+				Path:  "/metadata/labels/example.com~0my",
 				Value: "label",
 			}},
 		},


### PR DESCRIPTION
### :pencil: Description
- Many labels/annotations use `/` and `~` (though far more the former). However that is also a special character in json patching. These characters simply need to be escaped before the patch is created. 

### :pencil: Customer Notes
- _Provide relevant details for customers - what changed from a configuration perspective and/or what changes do they
need to incorporate in order to upgrade to this version?_
n/a

### :heavy_check_mark: Checklist
- [x] [Semantic Versioning](https://semver.org/) present in commit message.

### [Semantic Versioning](https://semver.org/)
1. fix(pencil): patches a bug ([PATCH](http://semver.org/#summary)); e.g., fix(pencil): fixed a bug
2. feat(pencil): new feature ([MINOR](http://semver.org/#summary)); e.g., feat(pencil): added a feature
3. BREAKING CHANGE/perf(pencil): footer BREAKING CHANGE:, breaking change ([MAJOR](http://semver.org/#summary)); e.g., perf(pencil): api change