### PR TITLE
feat(pencil): Add ability to fail admission on missing sidecar configmap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,5 +56,8 @@ follow-logs:
 install-sample-container:
 	helm upgrade -i inject-container ./sample/chart/echo-server/. --namespace=sample --create-namespace
 
+install-fail-on-missing:
+	helm upgrade -i inject-container ./sample/chart/echo-server-fail-on-missing/. --namespace=sample --create-namespace
+
 install-sample-init-container:
 	helm upgrade -i inject-init-container ./sample/chart/nginx/. --namespace=sample --create-namespace

--- a/pkg/webhook/sidecarhandler.go
+++ b/pkg/webhook/sidecarhandler.go
@@ -17,7 +17,7 @@ import (
 )
 
 const (
-	skipOnMissingSidecarAnnotation = "skipOnMissingSidecar"
+	skipOnMissingAnnotation = "skipOnMissing"
 )
 
 // Sidecar Kubernetes Sidecar Injector schema
@@ -54,10 +54,10 @@ func (patcher *SidecarInjectorPatcher) skipOnMissingSidecar(pod corev1.Pod) bool
 	if pod.GetAnnotations() != nil {
 		annotations = pod.GetAnnotations()
 	}
-	if skipOnMissingSideCar, ok := annotations[patcher.InjectPrefix+"/"+skipOnMissingSidecarAnnotation]; ok {
+	if skipOnMissingSideCar, ok := annotations[patcher.InjectPrefix+"/"+skipOnMissingAnnotation]; ok {
 		result, err := strconv.ParseBool(skipOnMissingSideCar)
 		if err != nil {
-			log.Warnf("error parsing bool values from annotation %s - %v", patcher.InjectPrefix+"/"+skipOnMissingSidecarAnnotation, err)
+			log.Warnf("error parsing bool values from annotation %s - %v", patcher.InjectPrefix+"/"+skipOnMissingAnnotation, err)
 			return true
 		}
 		return result
@@ -152,6 +152,7 @@ func (patcher *SidecarInjectorPatcher) PatchPodCreate(ctx context.Context, names
 	var patches []admission.PatchOperation
 	if configmapSidecarNames := patcher.configmapSidecarNames(namespace, pod); configmapSidecarNames != nil {
 		skipOnMissing := patcher.skipOnMissingSidecar(pod)
+		log.Infof("skipOnMissing: %t", skipOnMissing)
 		for _, configmapSidecarName := range configmapSidecarNames {
 			configmapSidecar, err := patcher.K8sClient.CoreV1().ConfigMaps(namespace).Get(ctx, configmapSidecarName, metav1.GetOptions{})
 			if k8serrors.IsNotFound(err) {

--- a/pkg/webhook/sidecarhandler_test.go
+++ b/pkg/webhook/sidecarhandler_test.go
@@ -666,7 +666,7 @@ func Test_createObjectPatches(t *testing.T) {
 	}
 }
 
-func TestSideCarInjectorPatcher_skipOnMissingSideCar(t *testing.T) {
+func TestSideCarInjectorPatcher_skipOnMissing(t *testing.T) {
 	type fields struct {
 		K8sClient                kubernetes.Interface
 		InjectPrefix             string
@@ -685,7 +685,7 @@ func TestSideCarInjectorPatcher_skipOnMissingSideCar(t *testing.T) {
 		want   bool
 	}{
 		{
-			name: "test skipOnMissingSidecar false",
+			name: "test skipOnMissing false",
 			fields: fields{
 				K8sClient:    fake.NewSimpleClientset(),
 				InjectPrefix: "sidecar-injector.expedia.com",
@@ -693,14 +693,14 @@ func TestSideCarInjectorPatcher_skipOnMissingSideCar(t *testing.T) {
 			args: args{
 				pod: v1.Pod{ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"sidecar-injector.expedia.com/skipOnMissingSidecar": "false",
+						"sidecar-injector.expedia.com/skipOnMissing": "false",
 					},
 				}},
 			},
 			want: false,
 		},
 		{
-			name: "test skipOnMissingSidecar missing",
+			name: "test skipOnMissing missing",
 			fields: fields{
 				K8sClient:    fake.NewSimpleClientset(),
 				InjectPrefix: "sidecar-injector.expedia.com",
@@ -711,7 +711,7 @@ func TestSideCarInjectorPatcher_skipOnMissingSideCar(t *testing.T) {
 			want: true,
 		},
 		{
-			name: "test skipOnMissingSidecar true",
+			name: "test skipOnMissing true",
 			fields: fields{
 				K8sClient:    fake.NewSimpleClientset(),
 				InjectPrefix: "sidecar-injector.expedia.com",
@@ -719,14 +719,14 @@ func TestSideCarInjectorPatcher_skipOnMissingSideCar(t *testing.T) {
 			args: args{
 				pod: v1.Pod{ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"sidecar-injector.expedia.com/skipOnMissingSidecar": "true",
+						"sidecar-injector.expedia.com/skipOnMissing": "true",
 					},
 				}},
 			},
 			want: true,
 		},
 		{
-			name: "test skipOnMissingSidecar bad value",
+			name: "test skipOnMissing bad value",
 			fields: fields{
 				K8sClient:    fake.NewSimpleClientset(),
 				InjectPrefix: "sidecar-injector.expedia.com",
@@ -734,7 +734,7 @@ func TestSideCarInjectorPatcher_skipOnMissingSideCar(t *testing.T) {
 			args: args{
 				pod: v1.Pod{ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
-						"sidecar-injector.expedia.com/skipOnMissingSidecar": "garbage",
+						"sidecar-injector.expedia.com/skipOnMissing": "garbage",
 					},
 				}},
 			},
@@ -751,7 +751,7 @@ func TestSideCarInjectorPatcher_skipOnMissingSideCar(t *testing.T) {
 				AllowAnnotationOverrides: tt.fields.AllowAnnotationOverrides,
 				AllowLabelOverrides:      tt.fields.AllowLabelOverrides,
 			}
-			assert.Equalf(t, tt.want, patcher.skipOnMissingSidecar(tt.args.pod), "skipOnMissingSidecar(%v)", tt.args.pod)
+			assert.Equalf(t, tt.want, patcher.skipOnMissingSidecar(tt.args.pod), "skipOnMissing(%v)", tt.args.pod)
 		})
 	}
 }

--- a/sample/chart/echo-server-fail-on-missing/Chart.yaml
+++ b/sample/chart/echo-server-fail-on-missing/Chart.yaml
@@ -1,0 +1,5 @@
+name: inject-container-fail-on-missing
+home: https://github.com/expediagroup/kubernetes-sidecar-injector
+version: 0.0.1
+appVersion: "0.1"
+apiVersion:

--- a/sample/chart/echo-server-fail-on-missing/templates/deployment.yaml
+++ b/sample/chart/echo-server-fail-on-missing/templates/deployment.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ .Chart.Name }}
+  template:
+    metadata:
+      annotations:
+        sidecar-injector.expedia.com/inject: "missing-sidecar"
+        sidecar-injector.expedia.com/skipOnMissing: "false"
+      labels:
+        app.kubernetes.io/name: {{ .Chart.Name }}
+    spec:
+      serviceAccountName: {{ .Chart.Name }}
+      containers:
+        - name: echo-server
+          image: hashicorp/http-echo:alpine
+          imagePullPolicy: IfNotPresent
+          args:
+            - -listen=:8080
+            - -text="hello world"

--- a/sample/chart/echo-server-fail-on-missing/templates/service.yaml
+++ b/sample/chart/echo-server-fail-on-missing/templates/service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: {{ .Chart.Name }}
+spec:
+  ports:
+    - port: 8080
+      targetPort: 8080
+  type: NodePort
+  selector:
+    app.kubernetes.io/name: {{ .Chart.Name }}

--- a/sample/chart/echo-server-fail-on-missing/templates/serviceaccount.yaml
+++ b/sample/chart/echo-server-fail-on-missing/templates/serviceaccount.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Chart.Name }}
+  namespace: {{ .Release.Namespace }}
+


### PR DESCRIPTION
### :pencil: Description
- Add ability to fail admission on missing sidecar configmap

### :pencil: Customer Notes
- https://github.com/ExpediaGroup/kubernetes-sidecar-injector/issues/55
- `sidecar-injector.expedia.com/skipOnMissingSidecar: true/false`

### :heavy_check_mark: Checklist
- [x] [Semantic Versioning](https://semver.org/) present in commit message.

### [Semantic Versioning](https://semver.org/)
1. fix(pencil): patches a bug ([PATCH](http://semver.org/#summary)); e.g., fix(pencil): fixed a bug
2. feat(pencil): new feature ([MINOR](http://semver.org/#summary)); e.g., feat(pencil): added a feature
3. BREAKING CHANGE/perf(pencil): footer BREAKING CHANGE:, breaking change ([MAJOR](http://semver.org/#summary)); e.g., perf(pencil): api change