### PR TITLE
ci(pencil): Build and publish image for arm64

### DIFF
--- a/.github/workflows/helm_release.yaml
+++ b/.github/workflows/helm_release.yaml
@@ -68,6 +68,7 @@ jobs:
         with:
           push: true
           tags: ${{ steps.github-repository.outputs.lowercase }}:${{ steps.code-version-bump.outputs.newTag }},${{ steps.github-repository.outputs.lowercase }}:latest
+          platforms: linux/amd64,linux/arm64
 
       - name: Get specific changed files
         id: helm-specific-changes


### PR DESCRIPTION
### :pencil: Description
- Build and publish docker image for arm64. 

### :pencil: Customer Notes

We just started using your controller at Instacart - Thank you btw! - but some of our clusters are arm64 only. This should ensure an image is available for both amd64 and arm64.

### :heavy_check_mark: Checklist
- [x] [Semantic Versioning](https://semver.org/) present in commit message.

### [Semantic Versioning](https://semver.org/)
1. fix(pencil): patches a bug ([PATCH](http://semver.org/#summary)); e.g., fix(pencil): fixed a bug
2. feat(pencil): new feature ([MINOR](http://semver.org/#summary)); e.g., feat(pencil): added a feature
3. BREAKING CHANGE/perf(pencil): footer BREAKING CHANGE:, breaking change ([MAJOR](http://semver.org/#summary)); e.g., perf(pencil): api change