### PR TITLE
feat: add pod disruption budget

### DIFF
--- a/charts/kubernetes-sidecar-injector/Chart.yaml
+++ b/charts/kubernetes-sidecar-injector/Chart.yaml
@@ -1,6 +1,6 @@
 name: kubernetes-sidecar-injector
 home: https://github.com/ExpediaGroup/kubernetes-sidecar-injector
-version: 1.2.0
+version: 1.3.0
 apiVersion: v2
 appVersion: "1.4.0"
 keywords:

--- a/charts/kubernetes-sidecar-injector/Chart.yaml
+++ b/charts/kubernetes-sidecar-injector/Chart.yaml
@@ -1,6 +1,6 @@
 name: kubernetes-sidecar-injector
 home: https://github.com/ExpediaGroup/kubernetes-sidecar-injector
-version: 1.3.0
+version: 1.2.0
 apiVersion: v2
 appVersion: "1.4.0"
 keywords:

--- a/charts/kubernetes-sidecar-injector/templates/mutatingwebhook.yaml
+++ b/charts/kubernetes-sidecar-injector/templates/mutatingwebhook.yaml
@@ -152,3 +152,19 @@ spec:
         - name: {{ .Release.Name }}-certs
           secret:
             secretName: {{ include "certs.secret.name" . }}
+---
+{{- if .Values.pdb.enabled }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels" . | indent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "common.labels" . | indent 6 }}
+{{- end }}

--- a/charts/kubernetes-sidecar-injector/templates/mutatingwebhook.yaml
+++ b/charts/kubernetes-sidecar-injector/templates/mutatingwebhook.yaml
@@ -152,19 +152,3 @@ spec:
         - name: {{ .Release.Name }}-certs
           secret:
             secretName: {{ include "certs.secret.name" . }}
----
-{{- if .Values.pdb.enabled }}
-apiVersion: policy/v1beta1
-kind: PodDisruptionBudget
-metadata:
-  name: {{ .Release.Name }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    {{- include "common.labels" . | indent 4 }}
-spec:
-  minAvailable: {{ .Values.pdb.minAvailable }}
-  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
-  selector:
-    matchLabels:
-      {{- include "common.labels" . | indent 6 }}
-{{- end }}

--- a/charts/kubernetes-sidecar-injector/templates/poddisruptionbudget.yaml
+++ b/charts/kubernetes-sidecar-injector/templates/poddisruptionbudget.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.pdb.create }}
+apiVersion: policy/v1beta1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ .Release.Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "common.labels" . | indent 4 }}
+spec:
+  minAvailable: {{ .Values.pdb.minAvailable }}
+  maxUnavailable: {{ .Values.pdb.maxUnavailable }}
+  selector:
+    matchLabels:
+      {{- include "common.labels" . | indent 6 }}
+{{- end }}

--- a/charts/kubernetes-sidecar-injector/values.yaml
+++ b/charts/kubernetes-sidecar-injector/values.yaml
@@ -19,7 +19,7 @@ podLabels: {}
 podSecurityContext: {}
 
 pdb:
-  enabled: false
+  create: false
   minAvailable: 1
   maxUnavailable: 1
 

--- a/charts/kubernetes-sidecar-injector/values.yaml
+++ b/charts/kubernetes-sidecar-injector/values.yaml
@@ -18,6 +18,11 @@ podAnnotations: {}
 podLabels: {}
 podSecurityContext: {}
 
+pdb:
+  enabled: true
+  minAvailable: 1
+  maxUnavailable: 1
+
 sidecars:
   dataKey: sidecars.yaml
 

--- a/charts/kubernetes-sidecar-injector/values.yaml
+++ b/charts/kubernetes-sidecar-injector/values.yaml
@@ -19,7 +19,7 @@ podLabels: {}
 podSecurityContext: {}
 
 pdb:
-  enabled: true
+  enabled: false
   minAvailable: 1
   maxUnavailable: 1
 


### PR DESCRIPTION
### :pencil: Description
Added pod disruption budget in the chart

Default is set to disabled

### :pencil: Customer Notes
- _Provide relevant details for customers - what changed from a configuration perspective and/or what changes do they
need to incorporate in order to upgrade to this version?_

### :heavy_check_mark: Checklist
- [ ] [Semantic Versioning](https://semver.org/) present in commit message.

### [Semantic Versioning](https://semver.org/)
1. fix(pencil): patches a bug ([PATCH](http://semver.org/#summary)); e.g., fix(pencil): fixed a bug
2. feat(pencil): new feature ([MINOR](http://semver.org/#summary)); e.g., feat(pencil): added a feature
3. BREAKING CHANGE/perf(pencil): footer BREAKING CHANGE:, breaking change ([MAJOR](http://semver.org/#summary)); e.g., perf(pencil): api change